### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -18,7 +18,7 @@
   },
   "suffix": ".bs.js",
   "bs-dependencies": [
-    "@aantron/repromise",
+    "reason-promise",
     "@glennsl/bs-json"
   ],
   "warnings": {

--- a/example/Index.re
+++ b/example/Index.re
@@ -1,8 +1,7 @@
 let client = Redis.make();
 
-client
-|> Redis.set(~key="foo", ~value="bar", ~existence=NX, ~expiration=EX(10))
-|> Redis.Promise.wait(res =>
+Redis.set(~key="foo", ~value="bar", ~existence=NX, ~expiration=EX(10), client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(Redis.SimpleStringReply.Ok) => Js.log2("set", "Ok")
      | Belt.Result.Ok(Redis.SimpleStringReply.Empty) =>
@@ -13,9 +12,8 @@ client
      }
    );
 
-client
-|> Redis.exists(~key="foo")
-|> Redis.Promise.wait(res =>
+Redis.exists(~key="foo", client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(true) => Js.log("exists")
      | Belt.Result.Ok(false) => Js.log("not exists")
@@ -23,9 +21,8 @@ client
      }
    );
 
-client
-|> Redis.get(~key="foo")
-|> Redis.Promise.wait(res =>
+Redis.get(~key="foo", client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(Some(value)) => Js.log2("get", value)
      | Belt.Result.Ok(None) => Js.log2("get", "No value")
@@ -33,9 +30,8 @@ client
      }
    );
 
-client
-|> Redis.scan(~cursor=Redis.Cursor.start, ~match="t*", ~count=1)
-|> Redis.Promise.wait(res =>
+Redis.scan(~cursor=Redis.Cursor.start, ~match="t*", ~count=1, client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok((cursor, results)) when Redis.Cursor.isLast(cursor) =>
        Js.log3("scan", "all results processed", results)
@@ -44,36 +40,32 @@ client
      }
    );
 
-client
-|> Redis.del(~keys=["foo"])
-|> Redis.Promise.wait(res =>
+Redis.del(~keys=["foo"], client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("del", value)
      | Belt.Result.Error(error) => Js.log2("del error", error)
      }
    );
 
-client
-|> Redis.hincrby(~key="foo", ~field="bar", ~value=1)
-|> Redis.Promise.wait(res =>
+Redis.hincrby(~key="foo", ~field="bar", ~value=1, client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("hincrby", value)
      | Belt.Result.Error(error) => Js.log2("hincrby error", error)
      }
    );
 
-client
-|> Redis.del(~keys=["foo"])
-|> Redis.Promise.wait(res =>
+Redis.del(~keys=["foo"], client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("del", value)
      | Belt.Result.Error(error) => Js.log2("del error", error)
      }
    );
 
-client
-|> Redis.hmset(~key="foo", ~values=Js.Dict.fromList([("bar", "baz")]))
-|> Redis.Promise.wait(res =>
+Redis.hmset(~key="foo", ~values=Js.Dict.fromList([("bar", "baz")]), client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(Redis.SimpleStringReply.Ok) => Js.log2("hmset", "Ok")
      | Belt.Result.Ok(Redis.SimpleStringReply.Empty) =>
@@ -84,9 +76,8 @@ client
      }
    );
 
-client
-|> Redis.hscan(~key="foo", ~cursor=Redis.Cursor.start)
-|> Redis.Promise.wait(res =>
+Redis.hscan(~key="foo", ~cursor=Redis.Cursor.start, client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok((cursor, results)) when Redis.Cursor.isLast(cursor) =>
        Js.log3("hscan", "all results processed", results)
@@ -95,45 +86,40 @@ client
      }
    );
 
-client
-|> Redis.del(~keys=["foo"])
-|> Redis.Promise.wait(res =>
+Redis.del(~keys=["foo"], client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("del", value)
      | Belt.Result.Error(error) => Js.log2("del error", error)
      }
    );
 
-client
-|> Redis.sadd(~key="foo", ~members=["one", "two", "three"])
-|> Redis.Promise.wait(res =>
+Redis.sadd(~key="foo", ~members=["one", "two", "three"], client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("sadd", value)
      | Belt.Result.Error(error) => Js.log2("sadd error", error)
      }
    );
 
-client
-|> Redis.scard(~key="foo")
-|> Redis.Promise.wait(res =>
+Redis.scard(~key="foo", client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("scard", value)
      | Belt.Result.Error(error) => Js.log2("scard error", error)
      }
    );
 
-client
-|> Redis.sismember(~key="foo", ~member="one")
-|> Redis.Promise.wait(res =>
+Redis.sismember(~key="foo", ~member="one", client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("sismember", value)
      | Belt.Result.Error(error) => Js.log2("sismember error", error)
      }
    );
 
-client
-|> Redis.del(~keys=["foo"])
-|> Redis.Promise.wait(res =>
+Redis.del(~keys=["foo"], client)
+->Promise.get(res =>
      switch (res) {
      | Belt.Result.Ok(value) => Js.log2("del", value)
      | Belt.Result.Error(error) => Js.log2("del error", error)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@aantron/repromise": "^0.6.0",
+    "reason-promise": "^1.0.2",
     "@glennsl/bs-json": "^3.0.0",
     "ioredis": "^4.6.2"
   },

--- a/src/Redis.re
+++ b/src/Redis.re
@@ -60,7 +60,7 @@ module Internal = {
       commandGet(error)->Belt.Option.flatMap(Command.nameGet);
   };
 
-  type promise = Repromise.Rejectable.t(Js.Json.t, JsError.t);
+  type promise = Promise.Js.t(Js.Json.t, JsError.t);
 
   let argsWithExistence = (value, args) => {
     switch (value) {
@@ -235,10 +235,6 @@ module Error = {
   };
 };
 
-module Promise = {
-  include Repromise;
-};
-
 module SimpleStringReply = {
   type t =
     | Ok
@@ -308,10 +304,10 @@ let make = () => Internal.make();
 let quit = client => {
   // TODO: they claim this is always OK
   Internal.quit(client)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(SimpleStringReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -323,10 +319,10 @@ let set = (~key, ~value, ~expiration=?, ~existence=?, client) => {
     |> Internal.argsWithExpiration(expiration)
     |> Internal.argsWithExistence(existence);
   Internal.set(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(SimpleStringReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -335,10 +331,10 @@ let set = (~key, ~value, ~expiration=?, ~existence=?, client) => {
 let get = (~key, client) => {
   let args = [|key|];
   Internal.get(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(BulkStringReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -348,10 +344,10 @@ let del = (~keys, client) => {
   let args = Belt.List.toArray(keys);
 
   Internal.del(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(IntegerReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -361,10 +357,10 @@ let del = (~keys, client) => {
 let exists = (~key, client) => {
   let args = [|key|];
   Internal.exists(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(BooleanReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -377,11 +373,11 @@ let scan = (~cursor, ~match=?, ~count=?, client) => {
     |> Internal.argsWithMatch(match)
     |> Internal.argsWithCount(count);
   Internal.scan(client, args)
-  |> Repromise.Rejectable.map(json => {
+  ->Promise.Js.map(json => {
        let result = ScanReply.decode(json);
        Belt.Result.Ok(result);
      })
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -390,10 +386,10 @@ let scan = (~cursor, ~match=?, ~count=?, client) => {
 let hincrby = (~key, ~field, ~value, client) => {
   let args = [|key, field, string_of_int(value)|];
   Internal.hincrby(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(IntegerReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -405,10 +401,10 @@ let hmset = (~key, ~values, client) => {
   let args = [|key|] |> Internal.argsWithDict(values);
 
   Internal.hmset(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(SimpleStringReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -422,7 +418,7 @@ let hscan = (~key, ~cursor, ~match=?, ~count=?, client) => {
     |> Internal.argsWithCount(count);
 
   Internal.hscan(client, args)
-  |> Repromise.Rejectable.map(json => {
+  ->Promise.Js.map(json => {
        let result =
          Json.Decode.map(
            ((cursor, keyValues)) =>
@@ -432,7 +428,7 @@ let hscan = (~key, ~cursor, ~match=?, ~count=?, client) => {
          );
        Belt.Result.Ok(result);
      })
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -443,10 +439,10 @@ let sadd = (~key, ~members, client) => {
   let args = Belt.Array.concat([|key|], Belt.List.toArray(members));
 
   Internal.sadd(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(IntegerReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -456,10 +452,10 @@ let scard = (~key, client) => {
   let args = [|key|];
 
   Internal.scard(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(IntegerReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
@@ -469,11 +465,22 @@ let sismember = (~key, ~member, client) => {
   let args = [|key, member|];
 
   Internal.sismember(client, args)
-  |> Repromise.Rejectable.map(json =>
+  ->Promise.Js.map(json =>
        Belt.Result.Ok(BooleanReply.decode(json))
      )
-  |> Repromise.Rejectable.catch(error => {
+  ->Promise.Js.catch(error => {
        let result = Belt.Result.Error(Error.classify(error));
        Promise.resolved(result);
      });
+};
+
+module Promise = {
+  type t('a) = Promise.t('a);
+  let make = Promise.pending;
+  let resolved = Promise.resolved;
+  let andThen = (f, p) => Promise.flatMap(p, f);
+  let map = (f, p) => Promise.map(p, f);
+  let wait = (f, p) => Promise.get(p, f);
+  let all = Promise.all;
+  let race = Promise.race;
 };

--- a/src/Redis.rei
+++ b/src/Redis.rei
@@ -60,7 +60,7 @@ module Error: {
 };
 
 module Promise: {
-  type t('a);
+  type t('a) = Promise.t('a);
   let make: unit => (t('a), 'a => unit);
   let resolved: 'a => t('a);
   let andThen: ('a => t('b), t('a)) => t('b);


### PR DESCRIPTION
Repromise became [reason-promise](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.

This PR adapts this repo to use reason-promise. The `Redis.Promise` module name is now probably redundant, but I kept it around for compatibility. I moved its definition to the bottom of `Redis.re` to avoid shadowing the new `Promise` module within most of `Redis.re`.

The rest of the change is a pretty straightforward rearrangement, according to the name and argument order changes.